### PR TITLE
LG off-line charging mode

### DIFF
--- a/init/init.cpp
+++ b/init/init.cpp
@@ -1173,6 +1173,8 @@ int main(int argc, char** argv) {
     std::string bootmode = GetProperty("ro.bootmode", "");
     if (bootmode == "charger") {
         am.QueueEventTrigger("charger");
+    } else if (bootmode == "chargerlogo") {
+        am.QueueEventTrigger("chargerlogo");
     } else {
         am.QueueEventTrigger("late-init");
     }


### PR DESCRIPTION
On LG devices, the bootmode "chargerlogo" indicates that the device is
in off-line charging mode.  Check for this mode and then trigger the
"chargerlogo" action defined in an LG init rc file (resides on the
vendor partition).